### PR TITLE
Feat/task 4746

### DIFF
--- a/build/azDevOps/azure/azuredevops-vars.yml
+++ b/build/azDevOps/azure/azuredevops-vars.yml
@@ -52,7 +52,7 @@ variables:
   - name: version_minor
     value: 0
   - name: version_patch
-    value: 0
+    value: 1
   - name: build_type
     ${{ if eq( variables['Build.SourceBranchName'], 'main' ) }}:
       value: "RELEASE"

--- a/java/src/main/java/com/amido/stacks/core/api/annotations/CreateAPIResponses.java
+++ b/java/src/main/java/com/amido/stacks/core/api/annotations/CreateAPIResponses.java
@@ -1,0 +1,53 @@
+package com.amido.stacks.core.api.annotations;
+
+import com.amido.stacks.core.api.dto.ErrorResponse;
+import com.amido.stacks.core.api.dto.response.ResourceCreatedResponse;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@ApiResponse(
+    responseCode = "201",
+    description = "Resource created",
+    content =
+        @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = ResourceCreatedResponse.class)))
+@ApiResponse(
+    responseCode = "400",
+    description = "Bad Request",
+    content =
+        @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = ErrorResponse.class)))
+@ApiResponse(
+    responseCode = "401",
+    description = "Unauthorized, Access token is missing or invalid",
+    content =
+        @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = ErrorResponse.class)))
+@ApiResponse(
+    responseCode = "403",
+    description = "Forbidden, the user does not have permission to execute this operation",
+    content =
+        @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = ErrorResponse.class)))
+@ApiResponse(
+    responseCode = "409",
+    description = "Conflict, an item already exists",
+    content =
+        @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = ErrorResponse.class)))
+@SecurityRequirement(name = "bearerAuth")
+public @interface CreateAPIResponses {}

--- a/java/src/main/java/com/amido/stacks/core/api/annotations/CreateAPIResponses.java
+++ b/java/src/main/java/com/amido/stacks/core/api/annotations/CreateAPIResponses.java
@@ -6,7 +6,6 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;

--- a/java/src/main/java/com/amido/stacks/core/api/annotations/DeleteAPIResponses.java
+++ b/java/src/main/java/com/amido/stacks/core/api/annotations/DeleteAPIResponses.java
@@ -1,0 +1,53 @@
+package com.amido.stacks.core.api.annotations;
+
+import com.amido.stacks.core.api.dto.ErrorResponse;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@ApiResponse(
+    responseCode = "200",
+    description = "Success",
+    content = @Content(mediaType = "application/json", schema = @Schema(hidden = true)))
+@ApiResponse(
+    responseCode = "204",
+    description = "No Content",
+    content = @Content(schema = @Schema(hidden = true)))
+@ApiResponse(
+    responseCode = "400",
+    description = "Bad Request",
+    content =
+        @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = ErrorResponse.class)))
+@ApiResponse(
+    responseCode = "401",
+    description = "Unauthorized, Access token is missing or invalid",
+    content =
+        @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = ErrorResponse.class)))
+@ApiResponse(
+    responseCode = "403",
+    description = "Forbidden, the user does not have permission to execute this operation",
+    content =
+        @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = ErrorResponse.class)))
+@ApiResponse(
+    responseCode = "409",
+    description = "Conflict, an item already exists",
+    content =
+        @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = ErrorResponse.class)))
+@SecurityRequirement(name = "bearerAuth")
+public @interface DeleteAPIResponses {}

--- a/java/src/main/java/com/amido/stacks/core/api/annotations/DeleteAPIResponses.java
+++ b/java/src/main/java/com/amido/stacks/core/api/annotations/DeleteAPIResponses.java
@@ -5,7 +5,6 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;

--- a/java/src/main/java/com/amido/stacks/core/api/annotations/ReadAPIResponses.java
+++ b/java/src/main/java/com/amido/stacks/core/api/annotations/ReadAPIResponses.java
@@ -5,7 +5,6 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;

--- a/java/src/main/java/com/amido/stacks/core/api/annotations/ReadAPIResponses.java
+++ b/java/src/main/java/com/amido/stacks/core/api/annotations/ReadAPIResponses.java
@@ -1,0 +1,31 @@
+package com.amido.stacks.core.api.annotations;
+
+import com.amido.stacks.core.api.dto.ErrorResponse;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@ApiResponse(
+    responseCode = "404",
+    description = "Menu Not Found",
+    content =
+        @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = ErrorResponse.class)))
+@ApiResponse(
+    responseCode = "400",
+    description = "Bad Request",
+    content =
+        @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = ErrorResponse.class)))
+@SecurityRequirement(name = "bearerAuth")
+public @interface ReadAPIResponses {}

--- a/java/src/main/java/com/amido/stacks/core/api/annotations/ReadAPIResponses.java
+++ b/java/src/main/java/com/amido/stacks/core/api/annotations/ReadAPIResponses.java
@@ -14,7 +14,7 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @ApiResponse(
     responseCode = "404",
-    description = "Menu Not Found",
+    description = "Resource not found",
     content =
         @Content(
             mediaType = "application/json",

--- a/java/src/main/java/com/amido/stacks/core/api/annotations/SearchAPIResponses.java
+++ b/java/src/main/java/com/amido/stacks/core/api/annotations/SearchAPIResponses.java
@@ -1,0 +1,24 @@
+package com.amido.stacks.core.api.annotations;
+
+import com.amido.stacks.core.api.dto.ErrorResponse;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@ApiResponse(
+    responseCode = "400",
+    description = "Bad Request",
+    content =
+        @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = ErrorResponse.class)))
+@SecurityRequirement(name = "bearerAuth")
+public @interface SearchAPIResponses {}

--- a/java/src/main/java/com/amido/stacks/core/api/annotations/SearchAPIResponses.java
+++ b/java/src/main/java/com/amido/stacks/core/api/annotations/SearchAPIResponses.java
@@ -5,7 +5,6 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;

--- a/java/src/main/java/com/amido/stacks/core/api/annotations/UpdateAPIResponses.java
+++ b/java/src/main/java/com/amido/stacks/core/api/annotations/UpdateAPIResponses.java
@@ -6,7 +6,6 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -45,13 +44,6 @@ import java.lang.annotation.Target;
 @ApiResponse(
     responseCode = "403",
     description = "Forbidden, the user does not have permission to execute this operation",
-    content =
-        @Content(
-            mediaType = "application/json",
-            schema = @Schema(implementation = ErrorResponse.class)))
-@ApiResponse(
-    responseCode = "404",
-    description = "Resource not found",
     content =
         @Content(
             mediaType = "application/json",

--- a/java/src/main/java/com/amido/stacks/core/api/annotations/UpdateAPIResponses.java
+++ b/java/src/main/java/com/amido/stacks/core/api/annotations/UpdateAPIResponses.java
@@ -1,0 +1,60 @@
+package com.amido.stacks.core.api.annotations;
+
+import com.amido.stacks.core.api.dto.ErrorResponse;
+import com.amido.stacks.core.api.dto.response.ResourceUpdatedResponse;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@ApiResponse(
+    responseCode = "200",
+    description = "Success",
+    content =
+        @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = ResourceUpdatedResponse.class)))
+@ApiResponse(
+    responseCode = "204",
+    description = "No Content",
+    content =
+        @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = ErrorResponse.class)))
+@ApiResponse(
+    responseCode = "400",
+    description = "Bad Request",
+    content =
+        @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = ErrorResponse.class)))
+@ApiResponse(
+    responseCode = "401",
+    description = "Unauthorized, Access token is missing or invalid",
+    content =
+        @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = ErrorResponse.class)))
+@ApiResponse(
+    responseCode = "403",
+    description = "Forbidden, the user does not have permission to execute this operation",
+    content =
+        @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = ErrorResponse.class)))
+@ApiResponse(
+    responseCode = "404",
+    description = "Resource not found",
+    content =
+        @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = ErrorResponse.class)))
+@SecurityRequirement(name = "bearerAuth")
+public @interface UpdateAPIResponses {}

--- a/java/src/main/java/com/amido/stacks/core/api/dto/response/ResourceUpdatedResponse.java
+++ b/java/src/main/java/com/amido/stacks/core/api/dto/response/ResourceUpdatedResponse.java
@@ -1,15 +1,11 @@
 package com.amido.stacks.core.api.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.util.UUID;
-
-/**
- * @author ArathyKrishna
- */
 @Data
 @NoArgsConstructor
 @AllArgsConstructor

--- a/java/src/main/java/com/amido/stacks/core/api/dto/response/ResourceUpdatedResponse.java
+++ b/java/src/main/java/com/amido/stacks/core/api/dto/response/ResourceUpdatedResponse.java
@@ -1,0 +1,19 @@
+package com.amido.stacks.core.api.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+/**
+ * @author ArathyKrishna
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ResourceUpdatedResponse {
+  @JsonProperty("id")
+  private UUID id = null;
+}


### PR DESCRIPTION
The proliferation of Swagger annotations means that there is a lot of duplication, and it makes it difficult to properly compose the controller operations into a single class.

Use Java annotation(s) to remove duplicated Swagger annotations from controller methods.